### PR TITLE
Update NASA & UN FAO project description with advisory role

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,10 +387,10 @@ footer{background:var(--deep);padding:6rem 4rem 3rem;position:relative;overflow:
         <span class="work-metric">~1M downloads</span>
       </div>
       <div class="work-card">
-        <p class="work-org">NASA &amp; UN FAO — Research</p>
+        <p class="work-org">NASA &amp; UN FAO — Research &amp; Advisory</p>
         <h3>Global-Scale ML Models</h3>
-        <p>Built predictive models from satellite and sensor data at 10km global resolution. Food security monitoring with uncertainty quantification.</p>
-        <span class="work-metric">2M+ time series</span>
+        <p>Built predictive models from satellite and sensor data at 10km global resolution. Food security monitoring with uncertainty quantification. Expert Advisory Group member for The State of Food and Agriculture 2025.</p>
+        <span class="work-metric">2M+ time series · SOFA 2025</span>
       </div>
       <div class="work-card">
         <p class="work-org">Gates Foundation — NLP</p>


### PR DESCRIPTION
## Summary
Updated the NASA & UN FAO project card to reflect expanded responsibilities and recent recognition in food security research.

## Changes Made
- Updated project role from "Research" to "Research & Advisory" to accurately represent current involvement
- Enhanced project description to include membership in the Expert Advisory Group for The State of Food and Agriculture 2025
- Updated metrics display to include "SOFA 2025" alongside the existing "2M+ time series" metric

## Details
These changes highlight the user's expanded role beyond research into advisory capacity, specifically recognizing their contribution to a major UN FAO publication on global food and agriculture. The metric update provides additional context about recent professional recognition and involvement in high-impact initiatives.

https://claude.ai/code/session_01KqgsXm9eaX6RVv3hQ8Wj7D